### PR TITLE
fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@ Cargo is a tool that helps you develop Rust. It does several things:
 Officially, Cargo is the package manager for Rust. This means that you can
 use Cargo to install and manage bits of other people's code.
 
-- A pacakge in Rust is called a Crate.
+- A package in Rust is called a Crate.
 - You can find Crates on http://crates.io
 - You list the Crates you want to use in the `Cargo.toml` file
 - You app keeps track of what crates you are using in the `Cargo.lock` file


### PR DESCRIPTION
_technically_ packages do exist, and they're one or more crates, but most people call packages crates, so just fix the typo, it's fine.
