### PR TITLE
Fix lifespan error

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,7 +200,8 @@ class: middle, left
 Example:
 
 ```rust
-let letters = String::from("ashley").chars();
+let name = String::from("ashley");
+let letters = name.chars();
 
 for l in letters {
   // do something cool with characters


### PR DESCRIPTION
`String::from()` needs a reference for the `chars()` method, but because it's chained in this fashion the reference goes out of scope at the end of the line. And then you get this error: `error: borrowed value does not live long enough`. This fix first assigns the `String` so that `chars()` can correctly use its reference.

It's not ideal, and goes against most modern programming norms for sure, but that's just the way Rust is right now. There is an RFC proposal to address this partical kind of case: https://github.com/kballard/rfcs/blob/2d3ff42b821ab80bd6a7b3b8fda0e1c238cc7de0/active/0000-better-temporary-lifetimes.md
