### PR TITLE
fix mismatched type error

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,7 +282,7 @@ a Type inside, e.g. `Option<u32>`.
 For example, if a parameter is optional you'd write:
 
 ```rust
-fn greeting(name: Option<&str>) -> &str {
+fn greeting(name: Option<&str>) -> String {
   let who = match name {
     Some(n) => n,
     None => "World",

--- a/index.html
+++ b/index.html
@@ -236,7 +236,7 @@ class: middle, left
 ## function signatures
 
 ```rust
-pub fn say_hello(name: &str) -> &str {
+pub fn say_hello(name: &str) -> String {
   let message = format!("hello, {}!", name);
   message
 }
@@ -326,7 +326,7 @@ inline with your code.
 To designate a test write `#[test]` above a code block with asserts:
 
 ```rust
-fn say_hello(name: &str) -> &str {
+fn say_hello(name: &str) -> String {
   let who = match name {
     Some(n) => n,
     None => "World",

--- a/index.html
+++ b/index.html
@@ -336,9 +336,9 @@ fn say_hello(name: &str) -> String {
 
 #[test]
 fn it_should_say_hello() {
-  assert_eq!(say_hello(None), "Hello, World!");
-  assert_ne!(say_hello(Some("ashley")), "Hello, World!");
-  assert_eq!(say_hello(Some("ashley")), "Hello, ashley!");
+  assert_eq!(say_hello(None), String::from("Hello, World!"));
+  assert_eq!(say_hello(Some("World")), String::from("Hello, World!"));
+  assert_eq!(say_hello(Some("ashley")), String::from(("Hello, ashley!"));
 }
 ```
 


### PR DESCRIPTION
The `format!` macro returns a `String`. This fixes the mismatched type error on a couple return values.
